### PR TITLE
Release 9.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pip" %}
-{% set version = "8.1.2" %}
-{% set sha256 = "4d24b03ffa67638a3fa931c09fd9e0273ffa904e95ebebe7d4b1a54c93d7b732" %}
+{% set version = "9.0.0" %}
+{% set sha256 = "f62fb70e7e000e46fce12aaeca752e5281a5446977fe5a75ab4189a43b3f8793" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
```
**9.0.0 (2016-11-02)**

* **BACKWARD INCOMPATIBLE** Remove the attempted autodetection of requirement
  names from URLs, URLs must include a name via ``#egg=``.

* **DEPRECATION** ``pip install --egg`` have been deprecated and will be
  removed in the future. This "feature" has a long list of drawbacks which 
  break nearly all of pip's other features in subtle and hard-to-diagnose
  ways.

* **DEPRECATION** ``--default-vcs`` option (:issue:`4052`).

* **WARNING** pip 9 cache can break forward compatibility with previous pip
  versions if your package repository allows chunked responses (:issue:`4078`).

* Add a ``pip check`` command to check installed packages dependencies
  (:pull:`3750`).

* Add option allowing user to abort pip operation if file/directory exists

* Add Appveyor CI

* Uninstall existing packages when performing an editable installation of
  the same packages (:issue:`1548`).

* ``pip show`` is less verbose by default. ``--verbose`` prints multiline fields.
  (:pull:`3858`).

* Add optional column formatting to ``pip list`` (:issue:`3651`).

* Add ``--not-required`` option to ``pip list``, which lists packages that are
  not dependencies of other packages.

* Fix builds on systems with symlinked ``/tmp`` directory for custom
  builds such as numpy (:pull:`3701`).

* Fix regression in ``pip freeze``: when there is more than one git remote,
  priority is given to the remote named ``origin`` (:pull:`3708`, :issue:`3616`).

* Fix crash when calling ``pip freeze`` with invalid requirement installed
  (:pull:`3704`, :issue:`3681`).

* Allow multiple ``--requirement`` files in ``pip freeze`` (:pull:`3703`).

* Implementation of pep-503 ``data-requires-python``. When this field is
  present for a release link, pip will ignore the download when
  installing to a Python version that doesn't satisfy the requirement.

* ``pip wheel`` now works on editable packages too (it was only working on
  editable dependencies before); this allows running ``pip wheel`` on the result
  of ``pip freeze`` in presence of editable requirements (:pull:`3695`,
  :issue:`3291`).

* Load credentials from ``.netrc`` files (:pull:`3715`, :issue:`3569`).

* Add ``--platform``, ``--python-version``, ``--implementation`` and ``--abi`` parameters to
  ``pip download``. These allow utilities and advanced users to gather
  distributions for interpreters other than the one pip is being run on.
  (:pull:`3760`)

* Skip scanning virtual environments, even when venv/bin/python is a dangling
  symlink.

* Added ``pip completion`` support for the ``fish`` shell.

* Fix problems on Windows on Python 2 when username or hostname contains
  non-ASCII characters (:issue:`3463`, :pull:`3970`, :pull:`4000`).

* Use ``git fetch --tags`` to fetch tags in addition to everything else that
  is normally fetched; this is necessary in case a git requirement url
  points to a tag or commit that is not on a branch (:pull:`3791`)

* Normalize package names before using in ``pip show`` (:issue:`3976`)

* Raise when Requires-Python do not match the running version and add
  ``--ignore-requires-python`` option as escape hatch (:pull:`3846`).

* Report the correct installed version when performing an upgrade in some
  corner cases (:issue:`2382`)

* Add ``-i`` shorthand for ``--index`` flag in ``pip search``

* Do not optionally load C dependencies in requests (:issue:`1840`,
  :issue:`2930`, :issue:`3024`)

* Strip authentication from SVN url prior to passing it to ``svn``
  (:pull:`3697`, :issue:`3209`).

* Also install in platlib with ``--target`` option (:pull:`3694`, :issue:`3682`).

* Restore the ability to use inline comments in requirements files passed to
``pip freeze`` (:issue:`3680`).
```

cc @conda-forge/core