### PR TITLE
Release 9.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pip" %}
-{% set version = "9.0.0" %}
-{% set sha256 = "f62fb70e7e000e46fce12aaeca752e5281a5446977fe5a75ab4189a43b3f8793" %}
+{% set version = "9.0.1" %}
+{% set sha256 = "09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
```txt
**9.0.1 (2016-11-06)**

* Correct the deprecation message when not specifying a --format so that
it
  uses the correct setting name (``format``) rather than the incorrect
one
  (``list_format``) (:issue:`4058`).

* Fix ``pip check`` to check all available distributions and not just
the
  local ones (:issue:`4083`).

* Fix a crash on non ASCII characters from `lsb_release`
(:issue:`4062`).

* Fix an SyntaxError in an an used module of a vendored dependency
  (:issue:`4059`).

* Fix UNC paths on Windows (:issue:`4064`).
```