### PR TITLE
Fix Python version metadata

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   disable_pip: true
   entry_points:
     - pip = pip._internal.cli.main:main
@@ -18,10 +18,10 @@ build:
 
 requirements:
   host:
-    - python >=3
+    - python >=3.6
     - setuptools
   run:
-    - python >=3
+    - python >=3.6
     - setuptools
     - wheel
 


### PR DESCRIPTION
@conda-forge/pip I saw this getting pulled in to a environment with Python 3.5 (for legacy tests) but `pip` now requires 3.6.

If there are no objections I'll also open a PR to mark `21.0 *_0` as broken (I'm not convinced it's worth patching for a single build).

@conda-forge-admin, please rerender

Fixes #67 