### PR TITLE
Fix installation of pip with setuptools and wheel dependencies for Python < 3.13

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,8 @@ requirements:
 
 test:
   requires:
-    - python {{ python_min }}
+    - python {{ python_min }}              # [with_setuptools_wheel]
+    - python 3.13.0                        # [not with_setuptools_wheel]
   commands:
     - pip -h
     - pip list

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
   disable_pip: true
   entry_points:
     - pip = pip._internal.cli.main:main
@@ -18,15 +18,15 @@ build:
 
 requirements:
   host:
-    - python {{ python_min }}  # [not with_setuptools_wheel]
-    - python {{ python_min }}  # [with_setuptools_wheel]
+    - python >=3.13.0a0                    # [not with_setuptools_wheel]
+    - python >={{ python_min }},<3.13.0a0  # [with_setuptools_wheel]
     - setuptools
     - wheel
   run:
-    - python >={{ python_min }}  # [not with_setuptools_wheel]
+    - python >=3.13.0a0                    # [not with_setuptools_wheel]
     - python >={{ python_min }},<3.13.0a0  # [with_setuptools_wheel]
-    - setuptools                  # [with_setuptools_wheel]
-    - wheel                       # [with_setuptools_wheel]
+    - setuptools                           # [with_setuptools_wheel]
+    - wheel                                # [with_setuptools_wheel]
 
 test:
   requires:


### PR DESCRIPTION
Fix https://github.com/conda-forge/pip-feedstock/issues/132 .

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
